### PR TITLE
Downgrade Python to 3.9

### DIFF
--- a/.github/workflows/twoops-tracker-cd.yml
+++ b/.github/workflows/twoops-tracker-cd.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9"]
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/twoops-tracker-ci.yml
+++ b/.github/workflows/twoops-tracker-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9"]
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/pants.toml
+++ b/pants.toml
@@ -1,7 +1,5 @@
 [GLOBAL]
-pants_version = "2.13.0"
-use_deprecated_directory_cli_args_semantics = false
-use_deprecated_pex_binary_run_semantics = false
+pants_version = "2.14.0"
 pythonpath = ["%(buildroot)s/pants-plugins"]
 
 backend_packages = [
@@ -34,7 +32,7 @@ root_patterns = [
 ]
 
 [python]
-interpreter_constraints = ["==3.10.*"]
+interpreter_constraints = ["==3.9.*"]
 
 [black]
 args = ["--preview"]


### PR DESCRIPTION
## Description

Since we can install only one version of Python at a time (in GitHub Actions at least for the moment), 3.9 is the highest version supported to run pants itself.

https://www.pantsbuild.org/docs/prerequisites

## Type of change

- [x] Chore (non-breaking change which does not add visible functionality but improves code quality)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

